### PR TITLE
Add sync missing endpoint and filter indexed uploads

### DIFF
--- a/apps/companion/src-tauri/src/lib.rs
+++ b/apps/companion/src-tauri/src/lib.rs
@@ -395,10 +395,10 @@ async fn filter_indexed(
                 should_replace = true;
             }
             if should_replace {
-                items[*index].ts = ts_value.clone();
+                items[*index].ts.clone_from(&ts_value);
                 *existing_ts = parsed_ts;
             } else if items[*index].ts.is_none() && ts_value.is_some() {
-                items[*index].ts = ts_value.clone();
+                items[*index].ts.clone_from(&ts_value);
             }
             continue;
         }

--- a/apps/companion/src-tauri/src/lib.rs
+++ b/apps/companion/src-tauri/src/lib.rs
@@ -386,7 +386,7 @@ async fn filter_indexed(
         let parsed_ts = ts_value.as_ref().and_then(|value| parse_timestamp(value));
         if let Some((index, existing_ts)) = dedupe.get_mut(&normalized) {
             let mut should_replace = match (&parsed_ts, existing_ts) {
-                (Some(new_ts), Some(current_ts)) => new_ts > *current_ts,
+                (Some(new_ts), Some(current_ts)) => new_ts > current_ts,
                 (Some(_), None) => true,
                 (None, Some(_)) => false,
                 (None, None) => false,

--- a/apps/companion/src-tauri/src/lib.rs
+++ b/apps/companion/src-tauri/src/lib.rs
@@ -385,7 +385,7 @@ async fn filter_indexed(
             });
         let parsed_ts = ts_value.as_ref().and_then(|value| parse_timestamp(value));
         if let Some((index, existing_ts)) = dedupe.get_mut(&normalized) {
-            let mut should_replace = match (&parsed_ts, existing_ts) {
+            let mut should_replace = match (&parsed_ts, existing_ts.as_ref()) {
                 (Some(new_ts), Some(current_ts)) => new_ts > current_ts,
                 (Some(_), None) => true,
                 (None, Some(_)) => false,
@@ -396,7 +396,7 @@ async fn filter_indexed(
             }
             if should_replace {
                 items[*index].ts.clone_from(&ts_value);
-                *existing_ts = parsed_ts;
+                *existing_ts = parsed_ts.clone();
             } else if items[*index].ts.is_none() && ts_value.is_some() {
                 items[*index].ts.clone_from(&ts_value);
             }

--- a/apps/companion/src/indexer.test.ts
+++ b/apps/companion/src/indexer.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const localStorageMock = {
+  getItem: vi.fn<(key: string) => string | null>().mockReturnValue(null),
+  setItem: vi.fn<(key: string, value: string) => void>(),
+  removeItem: vi.fn<(key: string) => void>(),
+}
+
+const windowStub: any = { localStorage: localStorageMock }
+
+vi.stubGlobal('window', windowStub)
+vi.stubGlobal('localStorage', localStorageMock)
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+const { filterChunkForUpload } = await import('./indexer')
+const { invoke } = await import('@tauri-apps/api/core')
+const mockedInvoke = vi.mocked(invoke)
+
+beforeEach(() => {
+  mockedInvoke.mockReset()
+  localStorageMock.getItem.mockReturnValue(null)
+})
+
+describe('filterChunkForUpload', () => {
+  it('omits already indexed items', async () => {
+    mockedInvoke.mockResolvedValueOnce([
+      { user_id: 'user-1', modality: 'image', uri: '/keep', ts: '2024-01-01T00:00:00Z' },
+    ])
+    const chunk = [
+      { path: '/keep', modality: 'image', modified: '2024-01-01T00:00:00Z' },
+      { path: '/skip', modality: 'image', modified: '2024-01-02T00:00:00Z' },
+    ]
+
+    const { filteredChunk } = await filterChunkForUpload('http://localhost:8080', chunk, 'user-1')
+
+    expect(filteredChunk).toHaveLength(1)
+    expect(filteredChunk[0].path).toBe('/keep')
+    expect(mockedInvoke).toHaveBeenCalledWith('filter_indexed', expect.objectContaining({
+      serverUrl: 'http://localhost:8080',
+      payload: expect.any(Object),
+    }))
+  })
+
+  it('falls back to original chunk on failure', async () => {
+    mockedInvoke.mockRejectedValueOnce(new Error('boom'))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const chunk = [
+      { path: '/a', modality: 'image', modified: '2024-01-01T00:00:00Z' },
+      { path: '/b', modality: 'image', modified: '2024-01-01T00:00:00Z' },
+    ]
+
+    const { filteredChunk } = await filterChunkForUpload('http://localhost:8080', chunk, 'user-1')
+
+    expect(filteredChunk).toHaveLength(2)
+    warnSpy.mockRestore()
+  })
+})

--- a/services/api-gateway/cmd/server/main.go
+++ b/services/api-gateway/cmd/server/main.go
@@ -77,6 +77,7 @@ func main() {
 	app.Options("/search", func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusNoContent) })
 	app.Post("/search", handlers.PostSearch)
 	app.Post("/sync", handlers.PostSync)
+	app.Post("/sync/missing", handlers.PostSyncMissing)
 	app.Post("/sync/stream", handlers.PostSyncStream)
 	app.Get("/stats", handlers.GetStats)
 	app.Post("/users/upsert", handlers.PostUpsertUser)

--- a/services/api-gateway/internal/handlers/sync_test.go
+++ b/services/api-gateway/internal/handlers/sync_test.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/TAURAAI/taura/api-gateway/internal/db"
+	"github.com/google/uuid"
+)
+
+func TestProcessSyncItemSkipsEmbeddingWhenExists(t *testing.T) {
+	ctx := context.Background()
+	originalUpsert := performUpsertMedia
+	originalCheck := mediaEmbeddingExists
+	defer func() {
+		performUpsertMedia = originalUpsert
+		mediaEmbeddingExists = originalCheck
+	}()
+
+	upsertCalls := 0
+	performUpsertMedia = func(ctx context.Context, database *db.Database, userUUID string, item MediaUpsert) (string, bool, error) {
+		upsertCalls++
+		if item.URI != "file:///foo.jpg" {
+			t.Fatalf("unexpected uri: %s", item.URI)
+		}
+		return "media-123", false, nil
+	}
+
+	checkCalls := 0
+	mediaEmbeddingExists = func(ctx context.Context, database *db.Database, mediaID string) (bool, error) {
+		checkCalls++
+		if mediaID != "media-123" {
+			t.Fatalf("unexpected media id: %s", mediaID)
+		}
+		return true, nil
+	}
+
+	item := MediaUpsert{
+		UserID:   uuid.NewString(),
+		Modality: "image",
+		URI:      "file:///foo.jpg",
+	}
+
+	res := processSyncItem(ctx, &db.Database{}, item)
+
+	if upsertCalls != 1 {
+		t.Fatalf("expected 1 upsert call, got %d", upsertCalls)
+	}
+	if checkCalls != 1 {
+		t.Fatalf("expected 1 embedding check call, got %d", checkCalls)
+	}
+	if res.requested != 0 {
+		t.Fatalf("expected requested=0 got %d", res.requested)
+	}
+	if res.queued != 0 {
+		t.Fatalf("expected queued=0 got %d", res.queued)
+	}
+}

--- a/services/api-gateway/internal/handlers/sync_test.go
+++ b/services/api-gateway/internal/handlers/sync_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/TAURAAI/taura/api-gateway/internal/db"
 	"github.com/google/uuid"
@@ -12,9 +13,11 @@ func TestProcessSyncItemSkipsEmbeddingWhenExists(t *testing.T) {
 	ctx := context.Background()
 	originalUpsert := performUpsertMedia
 	originalCheck := mediaEmbeddingExists
+	originalLookup := lookupExistingMediaTimestamp
 	defer func() {
 		performUpsertMedia = originalUpsert
 		mediaEmbeddingExists = originalCheck
+		lookupExistingMediaTimestamp = originalLookup
 	}()
 
 	upsertCalls := 0
@@ -24,6 +27,15 @@ func TestProcessSyncItemSkipsEmbeddingWhenExists(t *testing.T) {
 			t.Fatalf("unexpected uri: %s", item.URI)
 		}
 		return "media-123", false, nil
+	}
+
+	lookupCalls := 0
+	lookupExistingMediaTimestamp = func(ctx context.Context, database *db.Database, userUUID string, uri string) (*time.Time, error) {
+		lookupCalls++
+		if uri != "file:///foo.jpg" {
+			t.Fatalf("unexpected lookup uri: %s", uri)
+		}
+		return nil, nil
 	}
 
 	checkCalls := 0
@@ -46,6 +58,9 @@ func TestProcessSyncItemSkipsEmbeddingWhenExists(t *testing.T) {
 	if upsertCalls != 1 {
 		t.Fatalf("expected 1 upsert call, got %d", upsertCalls)
 	}
+	if lookupCalls != 1 {
+		t.Fatalf("expected 1 lookup call, got %d", lookupCalls)
+	}
 	if checkCalls != 1 {
 		t.Fatalf("expected 1 embedding check call, got %d", checkCalls)
 	}
@@ -54,5 +69,64 @@ func TestProcessSyncItemSkipsEmbeddingWhenExists(t *testing.T) {
 	}
 	if res.queued != 0 {
 		t.Fatalf("expected queued=0 got %d", res.queued)
+	}
+}
+
+func TestProcessSyncItemReembedsWhenTimestampChanges(t *testing.T) {
+	ctx := context.Background()
+	originalUpsert := performUpsertMedia
+	originalCheck := mediaEmbeddingExists
+	originalLookup := lookupExistingMediaTimestamp
+	defer func() {
+		performUpsertMedia = originalUpsert
+		mediaEmbeddingExists = originalCheck
+		lookupExistingMediaTimestamp = originalLookup
+	}()
+
+	performUpsertMedia = func(ctx context.Context, database *db.Database, userUUID string, item MediaUpsert) (string, bool, error) {
+		if item.URI != "file:///foo.jpg" {
+			t.Fatalf("unexpected uri: %s", item.URI)
+		}
+		return "media-123", false, nil
+	}
+
+	oldTS := time.Now().Add(-time.Hour).UTC()
+	lookupExistingMediaTimestamp = func(ctx context.Context, database *db.Database, userUUID string, uri string) (*time.Time, error) {
+		if uri != "file:///foo.jpg" {
+			t.Fatalf("unexpected lookup uri: %s", uri)
+		}
+		return &oldTS, nil
+	}
+
+	mediaEmbeddingExists = func(ctx context.Context, database *db.Database, mediaID string) (bool, error) {
+		if mediaID != "media-123" {
+			t.Fatalf("unexpected media id: %s", mediaID)
+		}
+		return true, nil
+	}
+
+	newTS := oldTS.Add(time.Minute).UTC().Format(time.RFC3339)
+	inline := "aGVsbG8="
+	item := MediaUpsert{
+		UserID:   uuid.NewString(),
+		Modality: "image",
+		URI:      "file:///foo.jpg",
+		TS:       &newTS,
+		BytesB64: &inline,
+	}
+
+	res := processSyncItem(ctx, &db.Database{}, item)
+
+	if res.requested != 1 {
+		t.Fatalf("expected requested=1 got %d", res.requested)
+	}
+	if res.queued != 0 {
+		t.Fatalf("expected queued=0 got %d", res.queued)
+	}
+	if len(res.embedFailures) != 1 {
+		t.Fatalf("expected 1 embed failure got %d", len(res.embedFailures))
+	}
+	if res.embedFailures[0].URI != item.URI {
+		t.Fatalf("unexpected failure uri: %s", res.embedFailures[0].URI)
 	}
 }


### PR DESCRIPTION
## Summary
- avoid re-requesting embeddings when media_vecs already contains a vector and expose a /sync/missing helper endpoint
- add a tauri filter_indexed command plus indexer filtering so only missing assets are uploaded
- cover the regression with go handler and Vitest indexer checks

## Testing
- cd services/api-gateway && go test ./...
- pnpm --filter companion test


------
https://chatgpt.com/codex/tasks/task_e_68e4175881cc832db95eba711bd24184